### PR TITLE
Improve docs and cleanup imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # Rech
+
+This repository contains a standalone Python 3.10+ script implementing a meet-in-the-middle optimizer for Teamfight Tactics (TFT) Set 14. The tool enumerates all possible teams of a configured size and scores them using customizable rules.
+
+## Features
+
+- **Exact search**: Splits the champion pool into two halves and compresses each side to drastically reduce combinations compared to a brute-force search.
+- **Trait-based scoring**: Flexible weighting for trait breakpoints with optional bonuses for high‑cost units or gold utilisation.
+- **Progress reporting**: Logs progress and improvements while running.
+- **Easily customizable**: Adjust the champion list, trait breakpoints and the scoring function directly in `Rech.py`.
+
+## Requirements
+
+- Python **3.10** or newer.
+- Only standard library modules are used. `black` and `flake8` are recommended for formatting and linting.
+
+Install the optional tools with:
+
+```bash
+pip install black flake8
+```
+
+## Usage
+
+1. Edit the `CHAMPION_DATA` block in `Rech.py` so it lists all Set 14 champions with correct traits and costs.
+2. Adjust `TRAIT_BREAKPOINTS` and `compute_score()` to match your desired scoring rules.
+3. Run the optimizer:
+
+```bash
+python Rech.py
+```
+
+The script prints progress information and finally displays the top teams according to your scoring function.
+
+## Development
+
+Before committing changes, run the formatting and lint checks:
+
+```bash
+black Rech.py --check
+flake8 Rech.py
+```
+
+If you extend the project with additional features, please also add tests under `tests/` using `pytest`.
+
+## License
+
+This project is provided as-is without warranty. Use and modify it at your own risk.

--- a/Rech.py
+++ b/Rech.py
@@ -31,44 +31,51 @@ Exaktheit:
 """
 
 from __future__ import annotations
-import itertools, math, time, sys, statistics
+
+import itertools
+import math
+import time
 from collections import defaultdict, namedtuple
 from dataclasses import dataclass
-from typing import List, Dict, Tuple, Iterable, Optional
+from typing import Dict, List, Tuple
 
 # ============================================================
 # ---------------------- KONFIGURATION -----------------------
 # ============================================================
 
 TEAM_SIZE = 8
-HIGH_COST_THRESHOLD = 4          # z.B. Cost >=4 als "High Cost" (anpassen falls anders gewünscht)
-TOP_K = 25                       # wie viele beste Teams am Ende anzeigen
-LOG_INTERVAL_SECONDS = 2.0       # Fortschritt-Ausgabe Frequenz
-ABORT_AFTER_SECONDS = None       # Optional: harte Abbruchzeit (None = aus)
+HIGH_COST_THRESHOLD = (
+    4  # z.B. Cost >=4 als "High Cost" (anpassen falls anders gewünscht)
+)
+TOP_K = 25  # wie viele beste Teams am Ende anzeigen
+LOG_INTERVAL_SECONDS = 2.0  # Fortschritt-Ausgabe Frequenz
+ABORT_AFTER_SECONDS = None  # Optional: harte Abbruchzeit (None = aus)
 
 # Gewichtung Trait-Level – Beispiel (Alternative Scoring aus deinem Wunsch)
 # Du kannst die Werte hier verändern / erweitern.
 LEVEL_WEIGHT = {
     0: 0.0,
-    1: 0.0,   # Falls einzelne Traits schon bei 1 etwas geben -> anpassen
+    1: 0.0,  # Falls einzelne Traits schon bei 1 etwas geben -> anpassen
     2: 25.0,
     3: 37.5,
     4: 50.0,
     5: 62.5,
     6: 75.0,
     7: 87.5,
-    8: 100.0
+    8: 100.0,
 }
 
 # Gold-Utilisierung: Beispielterm – bitte an deine bisherige Formel angleichen.
 # Der Score setzt sich unten aus (Summe Trait-Level-Werte) + evtl. Bonus zusammen.
 # Passe diese Parameter an deine vorherige Definition an, damit Zahlen wieder passen.
-GOLD_UTIL_LINEAR = 0.15      # Steigung für "mehr eingesetztes Gold"
-GOLD_UTIL_OFFSET = 0.0       # Basis
-LEFTOVER_PENALTY = 0.05      # Strafe für ungenutztes Gold (falls du das so hattest)
-MAX_POSSIBLE_GOLD = None     # Wenn du ein Gold-Limit hattest, trage es hier ein (z.B. 25). Sonst None.
+GOLD_UTIL_LINEAR = 0.15  # Steigung für "mehr eingesetztes Gold"
+GOLD_UTIL_OFFSET = 0.0  # Basis
+LEFTOVER_PENALTY = 0.05  # Strafe für ungenutztes Gold (falls du das so hattest)
+MAX_POSSIBLE_GOLD = (
+    None  # Wenn du ein Gold-Limit hattest, trage es hier ein (z.B. 25). Sonst None.
+)
 
-HIGH_COST_UNIT_BONUS = 0.4   # Bonus * pro* High-Cost-Unit (Beispiel)
+HIGH_COST_UNIT_BONUS = 0.4  # Bonus * pro* High-Cost-Unit (Beispiel)
 
 # ============================================================
 # ------------------- CHAMPION DATENBLOCK --------------------
@@ -85,75 +92,75 @@ HIGH_COST_UNIT_BONUS = 0.4   # Bonus * pro* High-Cost-Unit (Beispiel)
 # Unten ist ein *TEILWEISER* Platzhalter (NICHT vollständig / NICHT garantiert korrekt!).
 # -> Du musst vervollständigen. Falls du mir deine Liste gibst, liefere ich dir eine Version.
 #
-CHAMPION_DATA: List[Tuple[str,int,Tuple[str,...]]] = [
+CHAMPION_DATA: List[Tuple[str, int, Tuple[str, ...]]] = [
     # cost 1 Beispiele (PLATZHALTER!)
-    ("Annie",        1, ("A.M.P.","Street Demon")),
-    ("Naafiri",      1, ("A.M.P.","Overlord")),
-    ("Sylas",        1, ("A.M.P.","Anima Squad")),
-    ("Vi",           1, ("A.M.P.","Bastion")),
-    ("Brand",        1, ("Street Demon","Rapidfire")),
-    ("Dr Mundo",     1, ("Street Demon","Bruiser")),
-    ("Ekko",         1, ("Street Demon","Strategist")),
-    ("Jinx",         1, ("Street Demon","Marksman")),
-    ("Neeko",        1, ("Street Demon","Dynamo")),
-    ("Rengar",       1, ("Street Demon","Slayer")),
-    ("Samira",       1, ("Street Demon","Executioner")),
-    ("Zyra",         1, ("Street Demon","Vanguard")),
+    ("Annie", 1, ("A.M.P.", "Street Demon")),
+    ("Naafiri", 1, ("A.M.P.", "Overlord")),
+    ("Sylas", 1, ("A.M.P.", "Anima Squad")),
+    ("Vi", 1, ("A.M.P.", "Bastion")),
+    ("Brand", 1, ("Street Demon", "Rapidfire")),
+    ("Dr Mundo", 1, ("Street Demon", "Bruiser")),
+    ("Ekko", 1, ("Street Demon", "Strategist")),
+    ("Jinx", 1, ("Street Demon", "Marksman")),
+    ("Neeko", 1, ("Street Demon", "Dynamo")),
+    ("Rengar", 1, ("Street Demon", "Slayer")),
+    ("Samira", 1, ("Street Demon", "Executioner")),
+    ("Zyra", 1, ("Street Demon", "Vanguard")),
     # cost 2 Beispiele
-    ("Aurora",       2, ("Anima Squad","Dynamo")),
-    ("Illaoi",       2, ("Anima Squad","Bruiser")),
-    ("Leona",        2, ("Anima Squad","Bastion")),
-    ("Seraphine",    2, ("Anima Squad","Rapidfire")),
-    ("Vayne",        2, ("Anima Squad","Marksman")),
-    ("Xayah",        2, ("Anima Squad","Executioner")),
-    ("Yuumi",        2, ("Anima Squad","Strategist")),
+    ("Aurora", 2, ("Anima Squad", "Dynamo")),
+    ("Illaoi", 2, ("Anima Squad", "Bruiser")),
+    ("Leona", 2, ("Anima Squad", "Bastion")),
+    ("Seraphine", 2, ("Anima Squad", "Rapidfire")),
+    ("Vayne", 2, ("Anima Squad", "Marksman")),
+    ("Xayah", 2, ("Anima Squad", "Executioner")),
+    ("Yuumi", 2, ("Anima Squad", "Strategist")),
     # cost 3 Beispiele
-    ("Jax",          3, ("Exotech","Bruiser")),
-    ("Jhin",         3, ("Exotech","Marksman")),
-    ("Mordekaiser",  3, ("Exotech","Vanguard")),
-    ("Naafiri+",     3, ("Exotech","Slayer")),  # Platzhalter
-    ("Sejuani",      3, ("Exotech","Bastion")),
-    ("Varus",        3, ("Exotech","Rapidfire")),
-    ("Zeri",         3, ("Exotech","Dynamo")),
+    ("Jax", 3, ("Exotech", "Bruiser")),
+    ("Jhin", 3, ("Exotech", "Marksman")),
+    ("Mordekaiser", 3, ("Exotech", "Vanguard")),
+    ("Naafiri+", 3, ("Exotech", "Slayer")),  # Platzhalter
+    ("Sejuani", 3, ("Exotech", "Bastion")),
+    ("Varus", 3, ("Exotech", "Rapidfire")),
+    ("Zeri", 3, ("Exotech", "Dynamo")),
     # cost 4 Beispiele
-    ("Renekton",     4, ("Overlord","Divinicorp","Bastion")),
-    ("Kobuko",       4, ("Cyberboss","Bruiser")),
-    ("Garen",        4, ("God of the Net","Vanguard")),
-    ("Urgot",        4, ("BoomBot","Executioner")),
-    ("Viego",        4, ("Soul Killer","Golden Ox","Techie")),
-    ("Zac",          4, ("Virus","Bruiser")),
-    ("Kogmaw",       4, ("Virus","Marksman")),
+    ("Renekton", 4, ("Overlord", "Divinicorp", "Bastion")),
+    ("Kobuko", 4, ("Cyberboss", "Bruiser")),
+    ("Garen", 4, ("God of the Net", "Vanguard")),
+    ("Urgot", 4, ("BoomBot", "Executioner")),
+    ("Viego", 4, ("Soul Killer", "Golden Ox", "Techie")),
+    ("Zac", 4, ("Virus", "Bruiser")),
+    ("Kogmaw", 4, ("Virus", "Marksman")),
     # cost 5 Beispiele (PLATZHALTER!)
-    ("Twisted Fate", 5, ("Syndicate","Strategist")),
-    ("Graves",       5, ("Syndicate","Marksman")),
-    ("Shaco",        5, ("Syndicate","Slayer")),
-    ("Zed",          5, ("Syndicate","Executioner")),
-    ("Draven",       5, ("Divinicorp","Slayer")),
-    ("Galio",        5, ("Divinicorp","Bastion")),
-    ("Poppy",        5, ("Divinicorp","Vanguard")),
-    ("Darius",       5, ("Golden Ox","Vanguard")),
-    ("Jarvan IV",    5, ("Golden Ox","Strategist")),
-    ("Kindred",      5, ("Golden Ox","Rapidfire")),
-    ("Shyvana",      5, ("Golden Ox","Bruiser")),
-    ("Rhaast",       5, ("Soul Killer","Bruiser")),
-    ("Senna",        5, ("Soul Killer","Marksman")),
-    ("Aurora+",      5, ("Anima Squad","Dynamo")),  # ersetze
-    ("Veigar",       5, ("Nitro","Rapidfire")),
-    ("Ziggs",        5, ("Nitro","Techie")),
-    ("Zeri+",        5, ("Nitro","Marksman")),
-    ("Skarner",      5, ("Cypher","Bruiser")),
-    ("Sylas+",       5, ("Cypher","Bastion")),
-    ("Vi+",          5, ("Cypher","Vanguard")),
-    ("Vex",          5, ("Cypher","Dynamo")),
-    ("Ekko+",        5, ("Cypher","Strategist")),
-    ("Leblanc",      5, ("Overlord","Rapidfire")),
-    ("Miss Fortune", 5, ("Overlord","Marksman")),
-    ("Morgana",      5, ("Overlord","Executioner")),
-    ("Nidalee",      5, ("Overlord","Slayer")),
-    ("Aphelios",     5, ("God of the Net","Marksman")),
-    ("Aatrox?",      5, ("God of the Net","Slayer")),  # Platzhalter falls existiert
-    ("Braum",        5, ("God of the Net","Vanguard")),
-    ("Alistar",      5, ("God of the Net","Bruiser")),
+    ("Twisted Fate", 5, ("Syndicate", "Strategist")),
+    ("Graves", 5, ("Syndicate", "Marksman")),
+    ("Shaco", 5, ("Syndicate", "Slayer")),
+    ("Zed", 5, ("Syndicate", "Executioner")),
+    ("Draven", 5, ("Divinicorp", "Slayer")),
+    ("Galio", 5, ("Divinicorp", "Bastion")),
+    ("Poppy", 5, ("Divinicorp", "Vanguard")),
+    ("Darius", 5, ("Golden Ox", "Vanguard")),
+    ("Jarvan IV", 5, ("Golden Ox", "Strategist")),
+    ("Kindred", 5, ("Golden Ox", "Rapidfire")),
+    ("Shyvana", 5, ("Golden Ox", "Bruiser")),
+    ("Rhaast", 5, ("Soul Killer", "Bruiser")),
+    ("Senna", 5, ("Soul Killer", "Marksman")),
+    ("Aurora+", 5, ("Anima Squad", "Dynamo")),  # ersetze
+    ("Veigar", 5, ("Nitro", "Rapidfire")),
+    ("Ziggs", 5, ("Nitro", "Techie")),
+    ("Zeri+", 5, ("Nitro", "Marksman")),
+    ("Skarner", 5, ("Cypher", "Bruiser")),
+    ("Sylas+", 5, ("Cypher", "Bastion")),
+    ("Vi+", 5, ("Cypher", "Vanguard")),
+    ("Vex", 5, ("Cypher", "Dynamo")),
+    ("Ekko+", 5, ("Cypher", "Strategist")),
+    ("Leblanc", 5, ("Overlord", "Rapidfire")),
+    ("Miss Fortune", 5, ("Overlord", "Marksman")),
+    ("Morgana", 5, ("Overlord", "Executioner")),
+    ("Nidalee", 5, ("Overlord", "Slayer")),
+    ("Aphelios", 5, ("God of the Net", "Marksman")),
+    ("Aatrox?", 5, ("God of the Net", "Slayer")),  # Platzhalter falls existiert
+    ("Braum", 5, ("God of the Net", "Vanguard")),
+    ("Alistar", 5, ("God of the Net", "Bruiser")),
     # ... VERVOLLSTÄNDIGEN ...
 ]
 
@@ -165,31 +172,31 @@ CHAMPION_DATA: List[Tuple[str,int,Tuple[str,...]]] = [
 # ============================================================
 TRAIT_BREAKPOINTS: Dict[str, List[int]] = {
     # Beispiel: (2,4,6) oder (2,3,4,5,6,7,8)
-    "A.M.P.":        [2,3,4,5],
-    "Street Demon":  [2,3,4,5,6,7,8],
-    "Anima Squad":   [2,3,4,5,6,7,8],
-    "Exotech":       [2,3,4,5,6,7,8],
-    "Overlord":      [2,3,4,5,6,7,8],
-    "Divinicorp":    [2,3,4,5,6,7,8],
-    "Cyberboss":     [2,3,4,5,6,7,8],
-    "God of the Net":[2,3,4,5,6,7,8],
-    "Golden Ox":     [2,3,4,5,6,7,8],
-    "Soul Killer":   [2,3,4,5,6,7,8],
-    "Virus":         [2,3,4,5,6,7,8],
-    "Syndicate":     [2,3,4,5,6,7,8],
-    "Nitro":         [2,3,4,5,6,7,8],
-    "Cypher":        [2,3,4,5,6,7,8],
-    "BoomBot":       [2,3,4,5,6,7,8],
-    "Bruiser":       [2,4,6,8],
-    "Bastion":       [2,4,6,8],
-    "Vanguard":      [2,4,6,8],
-    "Marksman":      [2,4,6,8],
-    "Rapidfire":     [2,4,6,8],
-    "Executioner":   [2,4,6,8],
-    "Slayer":        [2,4,6,8],
-    "Strategist":    [2,4,6,8],
-    "Dynamo":        [2,3,4,5,6,7,8],
-    "Techie":        [2,3,4,5,6,7,8],
+    "A.M.P.": [2, 3, 4, 5],
+    "Street Demon": [2, 3, 4, 5, 6, 7, 8],
+    "Anima Squad": [2, 3, 4, 5, 6, 7, 8],
+    "Exotech": [2, 3, 4, 5, 6, 7, 8],
+    "Overlord": [2, 3, 4, 5, 6, 7, 8],
+    "Divinicorp": [2, 3, 4, 5, 6, 7, 8],
+    "Cyberboss": [2, 3, 4, 5, 6, 7, 8],
+    "God of the Net": [2, 3, 4, 5, 6, 7, 8],
+    "Golden Ox": [2, 3, 4, 5, 6, 7, 8],
+    "Soul Killer": [2, 3, 4, 5, 6, 7, 8],
+    "Virus": [2, 3, 4, 5, 6, 7, 8],
+    "Syndicate": [2, 3, 4, 5, 6, 7, 8],
+    "Nitro": [2, 3, 4, 5, 6, 7, 8],
+    "Cypher": [2, 3, 4, 5, 6, 7, 8],
+    "BoomBot": [2, 3, 4, 5, 6, 7, 8],
+    "Bruiser": [2, 4, 6, 8],
+    "Bastion": [2, 4, 6, 8],
+    "Vanguard": [2, 4, 6, 8],
+    "Marksman": [2, 4, 6, 8],
+    "Rapidfire": [2, 4, 6, 8],
+    "Executioner": [2, 4, 6, 8],
+    "Slayer": [2, 4, 6, 8],
+    "Strategist": [2, 4, 6, 8],
+    "Dynamo": [2, 3, 4, 5, 6, 7, 8],
+    "Techie": [2, 3, 4, 5, 6, 7, 8],
     # ... ggf. fehlende Traits ergänzen ...
 }
 
@@ -198,7 +205,7 @@ TRAIT_BREAKPOINTS: Dict[str, List[int]] = {
 # ============================================================
 # Baue Traitliste aus Championdaten (vereint) + Sortierung für stabile Indexe
 all_traits_set = set()
-for _,_,ts in CHAMPION_DATA:
+for _, _, ts in CHAMPION_DATA:
     for t in ts:
         all_traits_set.add(t)
 
@@ -210,10 +217,10 @@ if missing_in_champs:
 # Traits, die bei Champions vorkommen aber keine Breakpoints definiert haben -> Standard (2..8)
 undefined_break = [t for t in all_traits_set if t not in TRAIT_BREAKPOINTS]
 for t in undefined_break:
-    TRAIT_BREAKPOINTS[t] = [2,3,4,5,6,7,8]
+    TRAIT_BREAKPOINTS[t] = [2, 3, 4, 5, 6, 7, 8]
 
 TRAITS = sorted(TRAIT_BREAKPOINTS.keys())
-TRAIT_INDEX = {t:i for i,t in enumerate(TRAITS)}
+TRAIT_INDEX = {t: i for i, t in enumerate(TRAITS)}
 T = len(TRAITS)
 
 # Maximal relevante Zählung (Deckel) pro Trait -> letzter Breakpoint
@@ -221,19 +228,22 @@ TRAIT_CAP = [max(TRAIT_BREAKPOINTS[t]) for t in TRAITS]
 
 # Precompute LEVEL_FROM_COUNT: count -> levelValue (hier direkt Weight; wenn feinere Level nötig, anpassen)
 # Für Zählungen zwischen Breakpoints interpolieren wir *nicht* (einfach vorige Stufe).
-LEVEL_VALUE = [[0.0]*(cap+1) for cap in TRAIT_CAP]   # LEVEL_VALUE[traitIndex][count] -> Score-Beitrag dieses Traits
+LEVEL_VALUE = [
+    [0.0] * (cap + 1) for cap in TRAIT_CAP
+]  # LEVEL_VALUE[traitIndex][count] -> Score-Beitrag dieses Traits
 for tname, bps in TRAIT_BREAKPOINTS.items():
     ti = TRAIT_INDEX[tname]
     cap = TRAIT_CAP[ti]
     prev_val = 0.0
     prev_bp = 0
-    for bp in range(0, cap+1):
+    for bp in range(0, cap + 1):
         # Setze Level sobald Breakpoint erreicht
         # Level ist Anzahl Breakpoints <= bp
         level = sum(1 for b in bps if bp >= b)
         if level in LEVEL_WEIGHT:
             prev_val = LEVEL_WEIGHT[level]
         LEVEL_VALUE[ti][bp] = prev_val
+
 
 # ============================================================
 # ------------------ CHAMPION VORVERARBEITEN -----------------
@@ -243,16 +253,21 @@ class Champion:
     idx: int
     name: str
     cost: int
-    traits: Tuple[int,...]  # trait indices
+    traits: Tuple[int, ...]  # trait indices
     high_cost: int
 
+
 CHAMPIONS: List[Champion] = []
-for idx,(name,cost,traits) in enumerate(CHAMPION_DATA):
+for idx, (name, cost, traits) in enumerate(CHAMPION_DATA):
     trait_ids = tuple(TRAIT_INDEX[t] for t in traits)
     CHAMPIONS.append(
-        Champion(idx=idx, name=name, cost=cost,
-                 traits=trait_ids,
-                 high_cost=1 if cost >= HIGH_COST_THRESHOLD else 0)
+        Champion(
+            idx=idx,
+            name=name,
+            cost=cost,
+            traits=trait_ids,
+            high_cost=1 if cost >= HIGH_COST_THRESHOLD else 0,
+        )
     )
 
 N = len(CHAMPIONS)
@@ -261,14 +276,17 @@ if N > 64:
 print(f"Champions geladen: {N} | Traits: {T}")
 
 # Aufteilen in zwei Hälften (balanced)
-mid = N//2
+mid = N // 2
 LEFT = CHAMPIONS[:mid]
 RIGHT = CHAMPIONS[mid:]
+
 
 # ============================================================
 # -------------------- SCORE FUNKTION ------------------------
 # ============================================================
-def compute_score(trait_counts: List[int], total_cost: int, high_cost_units: int) -> float:
+def compute_score(
+    trait_counts: List[int], total_cost: int, high_cost_units: int
+) -> float:
     """
     trait_counts: *gedeckelte* counts (<= TRAIT_CAP[ti])
     Score = Sum TraitValues + GoldUtil + HighCostBonus - ggf. LeftoverPenalty
@@ -295,16 +313,18 @@ def compute_score(trait_counts: List[int], total_cost: int, high_cost_units: int
 
     return trait_sum + gold_util + high_cost_bonus - leftover_penalty
 
+
 # ============================================================
 # ---------------- SIGNATURE / KOMPRESSION -------------------
 # ============================================================
-Signature = namedtuple("Signature",
-                       ("size","cost","high","trait_counts","bitmask"))
+Signature = namedtuple("Signature", ("size", "cost", "high", "trait_counts", "bitmask"))
 
-def capped_counts_add(dst: List[int], trait_ids: Tuple[int,...]):
+
+def capped_counts_add(dst: List[int], trait_ids: Tuple[int, ...]):
     for ti in trait_ids:
         if dst[ti] < TRAIT_CAP[ti]:
             dst[ti] += 1
+
 
 def enumerate_half(champs: List[Champion], label: str):
     """
@@ -320,17 +340,17 @@ def enumerate_half(champs: List[Champion], label: str):
     costs = [c.cost for c in champs]
     highs = [c.high_cost for c in champs]
 
-    compressed: Dict[Tuple[int,int,Tuple[int,...]], Signature] = {}
+    compressed: Dict[Tuple[int, int, Tuple[int, ...]], Signature] = {}
     total_subsets = 0
 
     # Vorab Anzahl Kombinationen für Fortschritts-ETA
     # Sum_{k=0..TEAM_SIZE, k<=L} C(L,k)
-    total_target = sum(math.comb(L,k) for k in range(0, min(TEAM_SIZE,L)+1))
+    total_target = sum(math.comb(L, k) for k in range(0, min(TEAM_SIZE, L) + 1))
 
     last_log = start
     processed = 0
 
-    for k in range(0, min(TEAM_SIZE,L)+1):
+    for k in range(0, min(TEAM_SIZE, L) + 1):
         for combo in itertools.combinations(range(L), k):
             processed += 1
             total_subsets += 1
@@ -338,17 +358,19 @@ def enumerate_half(champs: List[Champion], label: str):
             now = time.time()
             if now - last_log >= LOG_INTERVAL_SECONDS:
                 pct = processed / total_target * 100
-                rate = processed / (now-start + 1e-9)
-                eta = (total_target - processed)/rate if rate>0 else 0
-                print(f"[{label}] {pct:5.2f}% k={k} subs={processed:,}/{total_target:,} "
-                      f"rate={rate:,.0f}/s eta={eta/60:5.1f}m "
-                      f"unique={len(compressed):,}")
+                rate = processed / (now - start + 1e-9)
+                eta = (total_target - processed) / rate if rate > 0 else 0
+                print(
+                    f"[{label}] {pct:5.2f}% k={k} subs={processed:,}/{total_target:,} "
+                    f"rate={rate:,.0f}/s eta={eta/60:5.1f}m "
+                    f"unique={len(compressed):,}"
+                )
                 last_log = now
 
             # Akkumulieren
             cost = 0
             highc = 0
-            trait_counts = [0]*T
+            trait_counts = [0] * T
             bitmask = 0
             for idx_local in combo:
                 ch = champs[idx_local]
@@ -358,17 +380,22 @@ def enumerate_half(champs: List[Champion], label: str):
                     if trait_counts[ti] < TRAIT_CAP[ti]:
                         trait_counts[ti] += 1
                 # Globale Bitposition = real champion index
-                bitmask |= (1 << ch.idx)
+                bitmask |= 1 << ch.idx
 
             key = (k, highc, tuple(trait_counts))
             prev = compressed.get(key)
             if prev is None or cost > prev.cost:
-                compressed[key] = Signature(k, cost, highc, tuple(trait_counts), bitmask)
+                compressed[key] = Signature(
+                    k, cost, highc, tuple(trait_counts), bitmask
+                )
 
     dur = time.time() - start
-    print(f"[{label}] DONE in {dur:,.1f}s | raw subsets={total_subsets:,} | unique={len(compressed):,} "
-          f"compression={total_subsets/len(compressed):.1f}x")
+    print(
+        f"[{label}] DONE in {dur:,.1f}s | raw subsets={total_subsets:,} | unique={len(compressed):,} "
+        f"compression={total_subsets/len(compressed):.1f}x"
+    )
     return list(compressed.values())
+
 
 # ============================================================
 # ------------------- COMBINE (MiM JOIN) ---------------------
@@ -378,13 +405,14 @@ class BestTeam:
     score: float
     cost: int
     high: int
-    trait_counts: Tuple[int,...]
+    trait_counts: Tuple[int, ...]
     bitmask: int
+
 
 def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
     # Gruppiere nach Größe
-    left_by_size: Dict[int,List[Signature]] = defaultdict(list)
-    right_by_size: Dict[int,List[Signature]] = defaultdict(list)
+    left_by_size: Dict[int, List[Signature]] = defaultdict(list)
+    right_by_size: Dict[int, List[Signature]] = defaultdict(list)
     for s in left_sigs:
         left_by_size[s.size].append(s)
     for s in right_sigs:
@@ -392,10 +420,10 @@ def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
 
     # Für einfache Obergrenzenanalyse Summen der Paare zählen
     total_pairings = 0
-    for k in range(0, TEAM_SIZE+1):
-        a = len(left_by_size.get(k,[]))
-        b = len(right_by_size.get(TEAM_SIZE-k,[]))
-        total_pairings += a*b
+    for k in range(0, TEAM_SIZE + 1):
+        a = len(left_by_size.get(k, []))
+        b = len(right_by_size.get(TEAM_SIZE - k, []))
+        total_pairings += a * b
     print(f"[COMBINE] Erwartete effektive Paarungen: {total_pairings:,}")
 
     best_list: List[BestTeam] = []
@@ -405,15 +433,15 @@ def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
     last_log = time.time()
     processed_pairs = 0
 
-    for k in range(0, TEAM_SIZE+1):
+    for k in range(0, TEAM_SIZE + 1):
         A_list = left_by_size.get(k, [])
-        B_list = right_by_size.get(TEAM_SIZE-k, [])
+        B_list = right_by_size.get(TEAM_SIZE - k, [])
         if not A_list or not B_list:
             continue
 
         # Optional: sortiere große Listen nach cost + high (heuristisch für schneller guten Floor)
-        A_list.sort(key=lambda s: (-(s.cost + 2*s.high)))
-        B_list.sort(key=lambda s: (-(s.cost + 2*s.high)))
+        A_list.sort(key=lambda s: (-(s.cost + 2 * s.high)))
+        B_list.sort(key=lambda s: (-(s.cost + 2 * s.high)))
 
         for sa in A_list:
             # Pre-caches
@@ -426,17 +454,25 @@ def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
                 now = time.time()
                 if now - last_log >= LOG_INTERVAL_SECONDS:
                     pct = processed_pairs / total_pairings * 100
-                    rate = processed_pairs / (now - last_log + LOG_INTERVAL_SECONDS)  # glättung
+                    rate = processed_pairs / (
+                        now - last_log + LOG_INTERVAL_SECONDS
+                    )  # glättung
                     elapsed = now - start_global
-                    eta = (total_pairings - processed_pairs) / (processed_pairs/elapsed) if processed_pairs>0 else 0
+                    eta = (
+                        (total_pairings - processed_pairs) / (processed_pairs / elapsed)
+                        if processed_pairs > 0
+                        else 0
+                    )
                     virt_cov = processed_pairs / math.comb(N, TEAM_SIZE) * 100
-                    print(f"[PROGRESS] {pct:6.3f}% pairs={processed_pairs:,}/{total_pairings:,} "
-                          f"virt_raw≈{virt_cov:.4f}% floor={best_floor:.2f}")
+                    print(
+                        f"[PROGRESS] {pct:6.3f}% pairs={processed_pairs:,}/{total_pairings:,} "
+                        f"virt_raw≈{virt_cov:.4f}% floor={best_floor:.2f}"
+                    )
                     last_log = now
 
                 b_counts = sb.trait_counts
                 # Merge trait counts (gedeckelt)
-                merged = [0]*T
+                merged = [0] * T
                 for ti in range(T):
                     c = a_counts[ti] + b_counts[ti]
                     if c > TRAIT_CAP[ti]:
@@ -452,18 +488,25 @@ def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
                 if score > best_floor:
                     improvements += 1
                     best_floor = score
-                    bt = BestTeam(score=score, cost=total_cost, high=high,
-                                  trait_counts=tuple(merged),
-                                  bitmask=sa.bitmask | sb.bitmask)
+                    bt = BestTeam(
+                        score=score,
+                        cost=total_cost,
+                        high=high,
+                        trait_counts=tuple(merged),
+                        bitmask=sa.bitmask | sb.bitmask,
+                    )
                     best_list.append(bt)
                     best_list.sort(key=lambda x: x.score, reverse=True)
                     if len(best_list) > TOP_K:
                         best_list = best_list[:TOP_K]
 
-                    print(f"[BEST] Score={score:.2f} Cost={total_cost} "
-                          f"Floor={best_floor:.2f} (Imp#{improvements})")
+                    print(
+                        f"[BEST] Score={score:.2f} Cost={total_cost} "
+                        f"Floor={best_floor:.2f} (Imp#{improvements})"
+                    )
 
     return best_list
+
 
 # ============================================================
 # --------------- REKONSTRUKTION TEAMNAMEN -------------------
@@ -475,18 +518,22 @@ def bitmask_to_team(bitmask: int) -> List[str]:
             names.append(ch.name)
     return names
 
-def summarize_traits(trait_counts: Tuple[int,...]) -> str:
+
+def summarize_traits(trait_counts: Tuple[int, ...]) -> str:
     parts = []
-    for ti,c in enumerate(trait_counts):
-        if c>0:
+    for ti, c in enumerate(trait_counts):
+        if c > 0:
             parts.append(f"{TRAITS[ti]}={c}")
     return ", ".join(parts)
+
 
 # ============================================================
 # --------------------------- MAIN ---------------------------
 # ============================================================
 start_global = time.time()
-print(f"=== START Meet-in-the-Middle | N={N} | TEAM_SIZE={TEAM_SIZE} | Raw Combos=C({N},{TEAM_SIZE})={math.comb(N,TEAM_SIZE):,} ===")
+print(
+    f"=== START Meet-in-the-Middle | N={N} | TEAM_SIZE={TEAM_SIZE} | Raw Combos=C({N},{TEAM_SIZE})={math.comb(N,TEAM_SIZE):,} ==="
+)
 
 # Phase 1
 left_sigs = enumerate_half(LEFT, "LEFT")
@@ -501,13 +548,19 @@ combine_dur = time.time() - combine_start
 
 total_dur = time.time() - start_global
 
-print(f"\n=== FERTIG in {total_dur/60:.2f} min (Combine Phase {combine_dur/60:.2f} min) ===")
+print(
+    f"\n=== FERTIG in {total_dur/60:.2f} min (Combine Phase {combine_dur/60:.2f} min) ==="
+)
 print(f"Top {len(best_teams)} Teams:")
 
 for rank, bt in enumerate(best_teams, start=1):
     names = bitmask_to_team(bt.bitmask)
-    print(f"{rank:2d}. Score={bt.score:.2f} Cost={bt.cost:2d} High={bt.high} | Traits: {summarize_traits(bt.trait_counts)}")
+    print(
+        f"{rank:2d}. Score={bt.score:.2f} Cost={bt.cost:2d} High={bt.high} | Traits: {summarize_traits(bt.trait_counts)}"
+    )
     print("    " + ", ".join(names))
 
-print("\nHinweis: Passe compute_score() und LEVEL_WEIGHT / Parameter an dein Original an, "
-      "damit die Score-Werte exakt den bisherigen entsprechen.")
+print(
+    "\nHinweis: Passe compute_score() und LEVEL_WEIGHT / Parameter an dein Original an, "
+    "damit die Score-Werte exakt den bisherigen entsprechen."
+)


### PR DESCRIPTION
## Summary
- expand the README with detailed usage and development notes
- cleanup unused imports and organize the import block in `Rech.py`

## Testing
- `black Rech.py --check`
- `flake8 Rech.py` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_687c1d85f854832784e725b9308fe1a5