### PR TITLE
Implement enhanced scoring with numba merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a standalone Python 3.10+ script implementing a meet-in
 ## Features
 
 - **Exact search**: Splits the champion pool into two halves and compresses each side to drastically reduce combinations compared to a brute-force search.
-- **Trait-based scoring**: Flexible weighting for trait breakpoints with optional bonuses for high‑cost units or gold utilisation.
+- **Trait-based scoring**: Flexible weighting for trait breakpoints with optional bonuses for high‑cost units or gold utilisation. A score decomposition helper explains the contributions of each part.
 - **Progress reporting**: Logs progress and improvements while running.
 - **Easily customizable**: Adjust the champion list, trait breakpoints and the scoring function directly in `Rech.py`.
 
@@ -24,7 +24,7 @@ pip install black flake8
 
 1. Edit the `CHAMPION_DATA` block in `Rech.py` so it lists all Set 14 champions with correct traits and costs.
 2. Adjust `TRAIT_BREAKPOINTS` and `compute_score()` to match your desired scoring rules.
-3. Run the optimizer:
+3. Run the optimizer (Numba is used if available):
 
 ```bash
 python Rech.py

--- a/Rech.py
+++ b/Rech.py
@@ -36,9 +36,21 @@ import itertools
 import logging
 import math
 import time
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
+
+import json
+import re
+
+import numpy as np
+
+try:
+    from numba import njit
+
+    NUMBA_AVAILABLE = True
+except Exception:
+    NUMBA_AVAILABLE = False
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
@@ -48,9 +60,7 @@ logger = logging.getLogger(__name__)
 # ============================================================
 
 TEAM_SIZE = 8
-HIGH_COST_THRESHOLD = (
-    4  # z.B. Cost >=4 als "High Cost" (anpassen falls anders gewünscht)
-)
+HIGH_COST_THRESHOLD = 4
 TOP_K = 25  # wie viele beste Teams am Ende anzeigen
 LOG_INTERVAL_SECONDS = 2.0  # Fortschritt-Ausgabe Frequenz
 ABORT_AFTER_SECONDS = None  # Optional: harte Abbruchzeit (None = aus)
@@ -58,28 +68,23 @@ ABORT_AFTER_SECONDS = None  # Optional: harte Abbruchzeit (None = aus)
 # Gewichtung Trait-Level – Beispiel (Alternative Scoring aus deinem Wunsch)
 # Du kannst die Werte hier verändern / erweitern.
 LEVEL_WEIGHT = {
-    0: 0.0,
-    1: 0.0,  # Falls einzelne Traits schon bei 1 etwas geben -> anpassen
-    2: 25.0,
-    3: 37.5,
-    4: 50.0,
+    2: 20,
+    3: 30,
+    4: 45,
     5: 62.5,
-    6: 75.0,
-    7: 87.5,
-    8: 100.0,
+    6: 85,
+    7: 100,
+    8: 120,
 }
 
 # Gold-Utilisierung: Beispielterm – bitte an deine bisherige Formel angleichen.
 # Der Score setzt sich unten aus (Summe Trait-Level-Werte) + evtl. Bonus zusammen.
 # Passe diese Parameter an deine vorherige Definition an, damit Zahlen wieder passen.
-GOLD_UTIL_LINEAR = 0.15  # Steigung für "mehr eingesetztes Gold"
-GOLD_UTIL_OFFSET = 0.0  # Basis
-LEFTOVER_PENALTY = 0.05  # Strafe für ungenutztes Gold (falls du das so hattest)
-MAX_POSSIBLE_GOLD = (
-    None  # Wenn du ein Gold-Limit hattest, trage es hier ein (z.B. 25). Sonst None.
-)
-
-HIGH_COST_UNIT_BONUS = 0.4  # Bonus * pro* High-Cost-Unit (Beispiel)
+GOLD_UTIL_LINEAR = 0.55
+LEFTOVER_PENALTY_FACTOR = 0.50
+AVG_TARGET_COST = 4.0
+HIGH_COST_UNIT_BONUS = 7.0
+MAX_POSSIBLE_GOLD = None
 
 # ============================================================
 # ------------------- CHAMPION DATENBLOCK --------------------
@@ -250,31 +255,49 @@ for tname, bps in TRAIT_BREAKPOINTS.items():
             prev_val = LEVEL_WEIGHT[level]
         LEVEL_VALUE[ti][bp] = prev_val
 
+# NumPy Tabellen für Numba-Optimierung
+MAX_COUNT_PER_TRAIT = max(TRAIT_CAP)
+LEVEL_LOOKUP_T = np.zeros((T, MAX_COUNT_PER_TRAIT + 1), dtype=np.int16)
+LEVEL_VALUE_T = np.zeros((T, MAX_COUNT_PER_TRAIT + 1), dtype=np.float64)
+for tname, bps in TRAIT_BREAKPOINTS.items():
+    ti = TRAIT_INDEX[tname]
+    for cnt in range(1, MAX_COUNT_PER_TRAIT + 1):
+        lvl = 0
+        for bp in bps:
+            if cnt >= bp:
+                lvl = bp
+        LEVEL_LOOKUP_T[ti, cnt] = lvl
+        if lvl:
+            LEVEL_VALUE_T[ti, cnt] = LEVEL_WEIGHT.get(bps.index(lvl) + 2, 0)
+
 
 # ============================================================
 # ------------------ CHAMPION VORVERARBEITEN -----------------
 # ============================================================
-@dataclass(frozen=True)
-class Champion:
-    idx: int
-    name: str
-    cost: int
-    traits: Tuple[int, ...]  # trait indices
-    high_cost: int
 
+variant_groups: Dict[str, List[int]] = defaultdict(list)
+CHAMPIONS: List[Dict] = []
 
-CHAMPIONS: List[Champion] = []
 for idx, (name, cost, traits) in enumerate(CHAMPION_DATA):
-    trait_ids = tuple(TRAIT_INDEX[t] for t in traits)
-    CHAMPIONS.append(
-        Champion(
-            idx=idx,
-            name=name,
-            cost=cost,
-            traits=trait_ids,
-            high_cost=1 if cost >= HIGH_COST_THRESHOLD else 0,
-        )
-    )
+    base = re.sub(r"\++$", "", name)
+    champ = {
+        "id": f"ch{idx}",
+        "idx": idx,
+        "name": name,
+        "base": base,
+        "cost": cost,
+        "traits": tuple(TRAIT_INDEX[t] for t in traits),
+        "high": cost >= HIGH_COST_THRESHOLD,
+    }
+    CHAMPIONS.append(champ)
+    variant_groups[base].append(idx)
+
+BASES = sorted(variant_groups.keys())
+BASE_INDEX = {b: i for i, b in enumerate(BASES)}
+for champ in CHAMPIONS:
+    champ["base_index"] = BASE_INDEX[champ["base"]]
+
+VARIANT_GROUPS = list(variant_groups.values())
 
 N = len(CHAMPIONS)
 if N > 64:
@@ -293,40 +316,87 @@ RIGHT = CHAMPIONS[mid:]
 def compute_score(
     trait_counts: List[int], total_cost: int, high_cost_units: int
 ) -> float:
-    """
-    trait_counts: *gedeckelte* counts (<= TRAIT_CAP[ti])
-    Score = Sum TraitValues + GoldUtil + HighCostBonus - ggf. LeftoverPenalty
-    Passe diese Funktion so an, dass sie identisch zur bisherigen in deinem Bruteforce Code ist!
-    """
+    """Berechnet den Score eines Teams nach den aktuellen Parametern."""
+
     trait_sum = 0.0
     for ti, cnt in enumerate(trait_counts):
         cnt = min(cnt, TRAIT_CAP[ti])
         trait_sum += LEVEL_VALUE[ti][cnt]
 
-    # Gold / Leftover:
-    gold_util = 0.0
-    leftover_penalty = 0.0
-    if MAX_POSSIBLE_GOLD is not None:
-        used = total_cost
-        leftover = max(0, MAX_POSSIBLE_GOLD - used)
-        gold_util = GOLD_UTIL_LINEAR * used + GOLD_UTIL_OFFSET
-        leftover_penalty = LEFTOVER_PENALTY * leftover
-    else:
-        # Wenn kein Limit definiert: nur leichte Belohnung für höheres Cost (optional)
-        gold_util = GOLD_UTIL_LINEAR * total_cost
-
+    gold_util = total_cost * GOLD_UTIL_LINEAR
+    leftover = TEAM_SIZE * AVG_TARGET_COST - total_cost
+    leftover_penalty = LEFTOVER_PENALTY_FACTOR * leftover if leftover > 0 else 0.0
     high_cost_bonus = high_cost_units * HIGH_COST_UNIT_BONUS
 
     return trait_sum + gold_util + high_cost_bonus - leftover_penalty
 
 
+if NUMBA_AVAILABLE:
+
+    @njit(cache=True, nogil=True, fastmath=True)
+    def merge_and_score_numba(
+        countsA,
+        countsB,
+        costA,
+        costB,
+        highA,
+        highB,
+        high_cost_unit_bonus,
+        gold_util_linear,
+        leftover_penalty_factor,
+        team_size,
+        avg_target_cost,
+        level_value,
+    ):
+        T = countsA.shape[0]
+        merged = np.empty(T, dtype=np.int16)
+        for i in range(T):
+            merged[i] = countsA[i] + countsB[i]
+        total_cost = costA + costB
+        total_high = highA + highB
+        trait_val = 0.0
+        for i in range(T):
+            cnt = merged[i]
+            if cnt >= level_value.shape[1]:
+                cnt = level_value.shape[1] - 1
+            trait_val += level_value[i, cnt]
+        high_val = total_high * high_cost_unit_bonus
+        gold_val = total_cost * gold_util_linear
+        leftover = team_size * avg_target_cost - total_cost
+        leftover_penalty = leftover_penalty_factor * leftover if leftover > 0 else 0.0
+        score = trait_val + high_val + gold_val - leftover_penalty
+        return (
+            merged,
+            total_cost,
+            total_high,
+            trait_val,
+            high_val,
+            gold_val,
+            leftover_penalty,
+            score,
+        )
+
+else:
+
+    def merge_and_score_numba(*args, **kwargs):
+        raise RuntimeError("Numba nicht verf\u00fcgbar")
+
+
 # ============================================================
 # ---------------- SIGNATURE / KOMPRESSION -------------------
 # ============================================================
-Signature = namedtuple("Signature", ("size", "cost", "high", "trait_counts", "bitmask"))
+@dataclass(frozen=True)
+class Signature:
+    size: int
+    cost: int
+    high: int
+    trait_counts: tuple[int, ...]
+    bitmask: int
+    base_mask: int
+    idxs: tuple[int, ...]
 
 
-def enumerate_half(champs: List[Champion], label: str):
+def enumerate_half(champs: List[Dict], label: str):
     """
     Erzeugt alle Teilmengen Größe 0..TEAM_SIZE.
     Kompression:
@@ -336,9 +406,10 @@ def enumerate_half(champs: List[Champion], label: str):
     start = time.time()
     L = len(champs)
     # Prebuild arrays für Traits pro Champion
-    trait_lists = [c.traits for c in champs]
-    costs = [c.cost for c in champs]
-    highs = [c.high_cost for c in champs]
+    trait_lists = [c["traits"] for c in champs]
+    costs = [c["cost"] for c in champs]
+    highs = [1 if c["high"] else 0 for c in champs]
+    bases = [c["base_index"] for c in champs]
 
     compressed: Dict[Tuple[int, int, Tuple[int, ...]], Signature] = {}
     total_subsets = 0
@@ -378,21 +449,31 @@ def enumerate_half(champs: List[Champion], label: str):
             highc = 0
             trait_counts = [0] * T
             bitmask = 0
+            base_mask = 0
+            idxs = []
             for idx_local in combo:
                 ch = champs[idx_local]
                 cost += costs[idx_local]
                 highc += highs[idx_local]
+                idxs.append(ch["idx"] if "idx" in ch else idx_local)
                 for ti in trait_lists[idx_local]:
                     if trait_counts[ti] < TRAIT_CAP[ti]:
                         trait_counts[ti] += 1
                 # Globale Bitposition = real champion index
-                bitmask |= 1 << ch.idx
+                bitmask |= 1 << (ch["idx"] if "idx" in ch else idx_local)
+                base_mask |= 1 << bases[idx_local]
 
             key = (k, highc, tuple(trait_counts))
             prev = compressed.get(key)
             if prev is None or cost > prev.cost:
                 compressed[key] = Signature(
-                    k, cost, highc, tuple(trait_counts), bitmask
+                    k,
+                    cost,
+                    highc,
+                    tuple(trait_counts),
+                    bitmask,
+                    base_mask,
+                    tuple(idxs),
                 )
 
     dur = time.time() - start
@@ -417,6 +498,7 @@ class BestTeam:
     high: int
     trait_counts: Tuple[int, ...]
     bitmask: int
+    idxs: tuple[int, ...]
 
 
 def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
@@ -454,8 +536,7 @@ def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
         B_list.sort(key=lambda s: (-(s.cost + 2 * s.high)))
 
         for sa in A_list:
-            # Pre-caches
-            a_counts = sa.trait_counts
+            a_counts = np.array(sa.trait_counts, dtype=np.int16)
             a_cost = sa.cost
             a_high = sa.high
             for sb in B_list:
@@ -475,20 +556,33 @@ def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
                     )
                     last_log = now
 
-                b_counts = sb.trait_counts
-                # Merge trait counts (gedeckelt)
-                merged = [0] * T
-                for ti in range(T):
-                    c = a_counts[ti] + b_counts[ti]
-                    if c > TRAIT_CAP[ti]:
-                        c = TRAIT_CAP[ti]
-                    merged[ti] = c
-                total_cost = a_cost + sb.cost
-                high = a_high + sb.high
-                if (MAX_POSSIBLE_GOLD is not None) and total_cost > MAX_POSSIBLE_GOLD:
+                if sa.base_mask & sb.base_mask:
                     continue
+                b_counts = np.array(sb.trait_counts, dtype=np.int16)
 
-                score = compute_score(merged, total_cost, high)
+                (
+                    merged,
+                    total_cost,
+                    total_high,
+                    trait_val,
+                    high_val,
+                    gold_val,
+                    leftover_penalty,
+                    score,
+                ) = merge_and_score_numba(
+                    a_counts,
+                    b_counts,
+                    a_cost,
+                    sb.cost,
+                    a_high,
+                    sb.high,
+                    HIGH_COST_UNIT_BONUS,
+                    GOLD_UTIL_LINEAR,
+                    LEFTOVER_PENALTY_FACTOR,
+                    TEAM_SIZE,
+                    AVG_TARGET_COST,
+                    LEVEL_VALUE_T,
+                )
 
                 if score > best_floor:
                     improvements += 1
@@ -496,9 +590,10 @@ def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
                     bt = BestTeam(
                         score=score,
                         cost=total_cost,
-                        high=high,
-                        trait_counts=tuple(merged),
+                        high=total_high,
+                        trait_counts=tuple(int(x) for x in merged),
                         bitmask=sa.bitmask | sb.bitmask,
+                        idxs=sa.idxs + sb.idxs,
                     )
                     best_list.append(bt)
                     best_list.sort(key=lambda x: x.score, reverse=True)
@@ -516,14 +611,115 @@ def combine_and_search(left_sigs: List[Signature], right_sigs: List[Signature]):
     return best_list
 
 
+def decompose_team_score(team: BestTeam) -> Dict:
+    comp = {
+        "trait_value": 0.0,
+        "high_value": team.high * HIGH_COST_UNIT_BONUS,
+        "gold_util_value": team.cost * GOLD_UTIL_LINEAR,
+        "leftover_penalty": 0.0,
+    }
+    for ti, cnt in enumerate(team.trait_counts):
+        cnt = min(cnt, LEVEL_VALUE_T.shape[1] - 1)
+        comp["trait_value"] += LEVEL_VALUE_T[ti, cnt]
+
+    leftover = TEAM_SIZE * AVG_TARGET_COST - team.cost
+    comp["leftover_penalty"] = (
+        LEFTOVER_PENALTY_FACTOR * leftover if leftover > 0 else 0.0
+    )
+    score = (
+        comp["trait_value"]
+        + comp["high_value"]
+        + comp["gold_util_value"]
+        - comp["leftover_penalty"]
+    )
+    pos_total = comp["trait_value"] + comp["high_value"] + comp["gold_util_value"]
+    comp_pct = {
+        "trait_value_pct": (
+            (comp["trait_value"] / pos_total * 100.0) if pos_total else 0.0
+        ),
+        "high_value_pct": (
+            (comp["high_value"] / pos_total * 100.0) if pos_total else 0.0
+        ),
+        "gold_util_pct": (
+            (comp["gold_util_value"] / pos_total * 100.0) if pos_total else 0.0
+        ),
+        "penalty_pct_of_score": (
+            (comp["leftover_penalty"] / score * 100.0) if score else 0.0
+        ),
+    }
+    comp.update(comp_pct)
+    comp["score"] = score
+    return comp
+
+
+def print_score_decomposition(top_teams: List[BestTeam], k: int = 5) -> None:
+    logger.info("\n=== SCORE DECOMPOSITION ===")
+    for rank, team in enumerate(top_teams[:k], start=1):
+        comp = decompose_team_score(team)
+        logger.info(
+            (
+                "[#%d] Score=%.2f (Trait=%.2f [%.1f%%], High=%.2f [%.1f%%], "
+                "GoldUtil=%.2f [%.1f%%], Penalty=%.2f [%.1f%% of final])"
+            ),
+            rank,
+            comp["score"],
+            comp["trait_value"],
+            comp["trait_value_pct"],
+            comp["high_value"],
+            comp["high_value_pct"],
+            comp["gold_util_value"],
+            comp["gold_util_pct"],
+            comp["leftover_penalty"],
+            comp["penalty_pct_of_score"],
+        )
+
+
+def rescore_teams_from_json(json_path: str, top_k: int = 20) -> List[Dict]:
+    with open(json_path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    name_index = {c["name"]: c["idx"] for c in CHAMPIONS}
+    rescored = []
+    for entry in raw:
+        names = entry.get("champions") or entry.get("team") or []
+        idxs = []
+        for n in names:
+            n = n.strip()
+            if n not in name_index:
+                logger.warning("Unknown champion name in result file: %s", n)
+                idxs = []
+                break
+            idxs.append(name_index[n])
+        if not idxs:
+            continue
+
+        trait_counts = [0] * T
+        cost = 0
+        high = 0
+        for i in idxs:
+            c = CHAMPIONS[i]
+            cost += c["cost"]
+            if c["high"]:
+                high += 1
+            for t in c["traits"]:
+                if trait_counts[t] < TRAIT_CAP[t]:
+                    trait_counts[t] += 1
+
+        score = compute_score(trait_counts, cost, high)
+        rescored.append({"champions": names, "score": score})
+
+    rescored.sort(key=lambda x: x["score"], reverse=True)
+    return rescored[:top_k]
+
+
 # ============================================================
 # --------------- REKONSTRUKTION TEAMNAMEN -------------------
 # ============================================================
 def bitmask_to_team(bitmask: int) -> List[str]:
     names = []
     for ch in CHAMPIONS:
-        if bitmask & (1 << ch.idx):
-            names.append(ch.name)
+        if bitmask & (1 << ch["idx"]):
+            names.append(ch["name"])
     return names
 
 
@@ -579,6 +775,8 @@ for rank, bt in enumerate(best_teams, start=1):
         summarize_traits(bt.trait_counts),
     )
     logger.info("    %s", ", ".join(names))
+
+print_score_decomposition(best_teams, k=min(5, len(best_teams)))
 
 logger.info(
     "\nHinweis: Passe compute_score() und LEVEL_WEIGHT / Parameter an dein Original an,"


### PR DESCRIPTION
## Summary
- add numba support and advanced score parameters
- compute champion variant groups and base masks
- optimise merging with numba and add score decomposition utilities
- update README to mention decomposition

## Testing
- `black Rech.py`
- `flake8 Rech.py`


------
https://chatgpt.com/codex/tasks/task_e_687c840f08548327a46aec8e62b21180