### PR TITLE
Implement CLI and enumeration tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This file provides guidance for AI agents (for example OpenAI Codex) when workin
 └─ .flake8    # flake8 configuration
 ```
 
-`Rech.py` downloads champion and trait data, defines two parameter sets (`P1`, `P2`) and contains helper functions for rescoring and progress reporting.
+`Rech.py` downloads champion and trait data, defines two parameter sets (`P1`, `P2`) and contains helper functions for rescoring and progress reporting. Parameters can now be overridden via CLI flags.
 
 ---
 
@@ -57,9 +57,10 @@ If a `tests/` directory is present also execute `pytest`.
 
 ## 6. Customisation Tips
 
-- Switch scoring presets by changing `ACTIVE_PARAM_SET` in `Rech.py`.
+- Switch scoring presets using the `--param-set` CLI flag (or change `ACTIVE_PARAM_SET`).
 - Adjust scoring behaviour via the `ScoreParams` dataclass or by modifying `compute_team_components()`.
 - Champion and trait data is downloaded from Data Dragon and cached in `dd_version_cache.json` and `tft_set14_cache.json.gz`.
 - The script automatically rescans `tft_full_bruteforce_results.json` or `.csv` files and prints score decompositions.
+- CLI flags like `--team-size`, `--top-k` and `--seed` allow quick parameter experiments.
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains `Rech.py`, a Python 3.10+ script implementing a meet-in
 - **Trait-based scoring**: configurable weights for trait breakpoints plus bonuses for high-cost units and gold utilisation.
 - **Progress reporting**: uses `tqdm` if available, otherwise a simple fallback progress bar.
 - **Result re-scoring**: existing JSON or CSV results named `tft_full_bruteforce_results.*` are rescored on start.
-- **Parameter sets**: two predefined parameter sets (`P1` and `P2`); select one via `ACTIVE_PARAM_SET`.
+- **Parameter sets**: two predefined parameter sets (`P1` and `P2`) selectable via `--param-set`.
 
 ## Requirements
 
@@ -27,10 +27,10 @@ pip install requests tqdm numba black flake8
 
 1. Run the optimizer:
    ```bash
-   python Rech.py
+   python Rech.py --param-set P1 --top-k 20 --team-size 8 --seed 123 --verbose 1
    ```
    The script downloads the latest Set 14 data and stores a cache in `tft_set14_cache.json.gz`.
-2. Adjust `ACTIVE_PARAM_SET` or modify `compute_team_components()` if you want to change scoring behaviour.
+2. Modify `--param-set` or edit `compute_team_components()` if you want to change scoring behaviour.
 3. Existing result files are detected automatically and rescored.
 
 The best teams are printed to the console and written to `demo_mim_top_combined.json`.


### PR DESCRIPTION
## Summary
- add argparse-based CLI for param-set, team-size, seed, and verbosity
- enumerate half signatures only for exact sizes
- use heap for top-k combine and print iteration count
- improve README usage section and project guide

## Testing
- `black Rech.py --check`
- `flake8 Rech.py`


------
https://chatgpt.com/codex/tasks/task_e_687cd936c7288327832bc3b534fbf475